### PR TITLE
Harbor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as build
+FROM python:3.11-slim AS build
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM python:3.11-slim as build
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+                build-essential gcc git
+
+WORKDIR /atrope
+RUN python -m venv /atrope/venv
+ENV PATH="/atrope/venv/bin:$PATH"
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+
+RUN pip install .
+
+FROM python:3.11-slim
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+                curl gnupg2 qemu-utils vim
+
+RUN curl -s \
+    https://dist.eugridpma.info/distribution/igtf/current/GPG-KEY-EUGridPMA-RPM-3 \
+    | apt-key add - \
+    && echo "deb https://repository.egi.eu/sw/production/cas/1/current egi-igtf core" > /etc/apt/sources.list.d/igtf.list \
+    && apt-get update \
+    && apt-get install -y ca-policy-egi-core
+
+RUN groupadd -g 1999 python && \
+    useradd -r -u 1999 -g python python
+
+WORKDIR /atrope
+
+COPY --chown=python:python --from=build /atrope/venv ./venv
+
+USER 1999
+
+ENV PATH="/atrope/venv/bin:$PATH"
+CMD [ "atrope" ]

--- a/atrope/__init__.py
+++ b/atrope/__init__.py
@@ -15,5 +15,4 @@
 import pbr.version
 
 
-__version__ = pbr.version.VersionInfo(
-    'atrope').release_string()
+__version__ = pbr.version.VersionInfo("atrope").release_string()

--- a/atrope/cache.py
+++ b/atrope/cache.py
@@ -24,9 +24,11 @@ from atrope import paths
 from atrope import utils
 
 opts = [
-    cfg.StrOpt('path',
-               default=paths.state_path_def('lists'),
-               help='Where instances are stored on disk'),
+    cfg.StrOpt(
+        "path",
+        default=paths.state_path_def("lists"),
+        help="Where instances are stored on disk",
+    ),
 ]
 
 CONF = cfg.CONF
@@ -44,10 +46,12 @@ class CacheManager(object):
     def _download_list(self, lst):
         LOG.info(f"Syncing list with ID '{lst.name}'")
         if lst.enabled:
-            LOG.info(f"List '{lst.name}' is enabled, checking if downloaded "
-                     "images are valid")
+            LOG.info(
+                f"List '{lst.name}' is enabled, checking if downloaded "
+                "images are valid"
+            )
             basedir = self.path / lst.name
-            imgdir = basedir / 'images'
+            imgdir = basedir / "images"
             if lst.trusted and lst.verified and not lst.expired:
                 utils.makedirs(imgdir)  # FIXME(aloga) pathlib
                 self._valid_paths.append(basedir)
@@ -55,15 +59,18 @@ class CacheManager(object):
                 for img in lst.get_subscribed_images():
                     try:
                         img.download(imgdir)
-                    except (exception.ImageVerificationFailed,
-                            exception.ImageDownloadFailed):
+                    except (
+                        exception.ImageVerificationFailed,
+                        exception.ImageDownloadFailed,
+                    ):
                         pass
                     else:
                         pass
                         self._valid_paths.append(pathlib.Path(img.location))
         else:
-            LOG.info(f"List '{lst.name}' is disabled, images will be "
-                     "marked for removal")
+            LOG.info(
+                f"List '{lst.name}' is disabled, images will be " "marked for removal"
+            )
 
     def _clean_invalid(self, base):
         LOG.info(f"Checking for invalid files in cache dir ({base}).")

--- a/atrope/cache.py
+++ b/atrope/cache.py
@@ -62,6 +62,7 @@ class CacheManager(object):
                     except (
                         exception.ImageVerificationFailed,
                         exception.ImageDownloadFailed,
+                        exception.ImageExpired,
                     ):
                         pass
                     else:

--- a/atrope/cmd/base.py
+++ b/atrope/cmd/base.py
@@ -1,8 +1,9 @@
 # Decorators for actions
 def args(*args, **kwargs):
     def _decorator(func):
-        func.__dict__.setdefault('args', []).insert(0, (args, kwargs))
+        func.__dict__.setdefault("args", []).insert(0, (args, kwargs))
         return func
+
     return _decorator
 
 
@@ -10,9 +11,11 @@ def name(name):
     """
     Give a command a alternate name
     """
+
     def _decorator(func):
-        func.__dict__['_cmd_name'] = name
+        func.__dict__["_cmd_name"] = name
         return func
+
     return _decorator
 
 

--- a/atrope/cmd/cli.py
+++ b/atrope/cmd/cli.py
@@ -25,7 +25,7 @@ CONF = cfg.CONF
 
 def main():
     atrope.config.parse_args(sys.argv)
-    log.setup(cfg.CONF, 'atrope')
+    log.setup(cfg.CONF, "atrope")
     commands.CommandManager().execute()
 
 

--- a/atrope/cmd/commands.py
+++ b/atrope/cmd/commands.py
@@ -36,10 +36,12 @@ def add_command_parsers(subparsers):
     version.CommandVersion(subparsers)
 
 
-command_opt = cfg.SubCommandOpt('command',
-                                title='Commands',
-                                help='Show available commands.',
-                                handler=add_command_parsers)
+command_opt = cfg.SubCommandOpt(
+    "command",
+    title="Commands",
+    help="Show available commands.",
+    handler=add_command_parsers,
+)
 
 CONF.register_cli_opt(command_opt)
 

--- a/atrope/cmd/image_list.py
+++ b/atrope/cmd/image_list.py
@@ -36,8 +36,9 @@ class BaseImageListCommand(base.BaseCommand):
 
 
 class CommandImageListIndex(BaseImageListCommand):
-    def __init__(self, parser, name="index",
-                 cmd_help="Show the configured image lists."):
+    def __init__(
+        self, parser, name="index", cmd_help="Show the configured image lists."
+    ):
         super(CommandImageListIndex, self).__init__(parser, name, cmd_help)
 
     def run(self):
@@ -55,21 +56,26 @@ class CommandImageListIndex(BaseImageListCommand):
 
 
 class CommandImageListFetch(BaseImageListCommand):
-    def __init__(self, parser, name="verify",
-                 cmd_help="Fetch and verify the configured image lists."):
+    def __init__(
+        self,
+        parser,
+        name="verify",
+        cmd_help="Fetch and verify the configured image lists.",
+    ):
         super(CommandImageListFetch, self).__init__(parser, name, cmd_help)
 
-        self.parser.add_argument("-c",
-                                 "--contents",
-                                 dest="contents",
-                                 default=False,
-                                 action="store_true",
-                                 help="Show the list contents")
+        self.parser.add_argument(
+            "-c",
+            "--contents",
+            dest="contents",
+            default=False,
+            action="store_true",
+            help="Show the list contents",
+        )
 
-        self.parser.add_argument("list",
-                                 default=None,
-                                 nargs='?',
-                                 help="Image list to fetch.")
+        self.parser.add_argument(
+            "list", default=None, nargs="?", help="Image list to fetch."
+        )
 
     def run(self):
         the_list = CONF.command.list
@@ -84,8 +90,12 @@ class CommandImageListFetch(BaseImageListCommand):
 
 
 class CommandImageListCache(BaseImageListCommand):
-    def __init__(self, parser, name="cache",
-                 cmd_help="Download images from configured image lists."):
+    def __init__(
+        self,
+        parser,
+        name="cache",
+        cmd_help="Download images from configured image lists.",
+    ):
         super(CommandImageListCache, self).__init__(parser, name, cmd_help)
 
     def run(self):
@@ -93,9 +103,13 @@ class CommandImageListCache(BaseImageListCommand):
 
 
 class CommandDispatch(BaseImageListCommand):
-    def __init__(self, parser, name="sync",
-                 cmd_help="Download images from configured image lists "
-                          "and sync them to the available dispatchers."):
+    def __init__(
+        self,
+        parser,
+        name="sync",
+        cmd_help="Download images from configured image lists "
+        "and sync them to the available dispatchers.",
+    ):
         super(CommandDispatch, self).__init__(parser, name, cmd_help)
 
     def run(self):

--- a/atrope/cmd/version.py
+++ b/atrope/cmd/version.py
@@ -19,8 +19,7 @@ from atrope.cmd import base
 
 
 class CommandVersion(base.BaseCommand):
-    def __init__(self, parser, name="version",
-                 cmd_help="Show verison and exit."):
+    def __init__(self, parser, name="version", cmd_help="Show verison and exit."):
         super(CommandVersion, self).__init__(parser, name, cmd_help)
 
     def run(self):

--- a/atrope/config.py
+++ b/atrope/config.py
@@ -21,6 +21,4 @@ log.register_options(cfg.CONF)
 
 
 def parse_args(argv, default_config_files=None):
-    cfg.CONF(argv[1:],
-             project='atrope',
-             default_config_files=default_config_files)
+    cfg.CONF(argv[1:], project="atrope", default_config_files=default_config_files)

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -31,9 +31,11 @@ CONF.import_opt("prefix", "atrope.dispatcher.manager", group="dispatchers")
 loading.register_auth_conf_options(CONF, CFG_GROUP)
 loading.register_session_conf_options(CONF, CFG_GROUP)
 
-opts = (loading.get_auth_common_conf_options() +
-        loading.get_session_conf_options() +
-        loading.get_auth_plugin_conf_options('password'))
+opts = (
+    loading.get_auth_common_conf_options()
+    + loading.get_session_conf_options()
+    + loading.get_auth_plugin_conf_options("password")
+)
 
 LOG = log.getLogger(__name__)
 
@@ -63,6 +65,7 @@ class Dispatcher(base.BaseDispatcher):
         - container_format
 
     """
+
     def __init__(self):
         self.client = self._get_glance_client()
         self.ks_client = self._get_ks_client()
@@ -71,25 +74,28 @@ class Dispatcher(base.BaseDispatcher):
         # container format? Or is it the image format? Try to do some ugly
         # magic and infer what is this for...
         # This makes me sad :-(
-        LOG.debug("The image spec is broken and I will try to guess what "
-                  "the container and the image format are. I cannot "
-                  "promise anything.")
+        LOG.debug(
+            "The image spec is broken and I will try to guess what "
+            "the container and the image format are. I cannot "
+            "promise anything."
+        )
 
     def _get_ks_client(self):
         auth_plugin = loading.load_auth_from_conf_options(CONF, CFG_GROUP)
-        sess = loading.load_session_from_conf_options(CONF, CFG_GROUP,
-                                                      auth=auth_plugin)
+        sess = loading.load_session_from_conf_options(CONF, CFG_GROUP, auth=auth_plugin)
         return ks_client_v3.Client(session=sess)
 
     def _get_glance_client(self, project_id=None):
         if project_id:
             auth_plugin = loading.load_auth_from_conf_options(
-                CONF, CFG_GROUP, project_id=project_id)
+                CONF, CFG_GROUP, project_id=project_id
+            )
         else:
             auth_plugin = loading.load_auth_from_conf_options(CONF, CFG_GROUP)
 
-        session = loading.load_session_from_conf_options(CONF, CFG_GROUP,
-                                                         auth=auth_plugin)
+        session = loading.load_session_from_conf_options(
+            CONF, CFG_GROUP, auth=auth_plugin
+        )
         return glanceclient.client.Client(2, session=session)
 
     def dispatch(self, image_name, image, is_public, **kwargs):
@@ -119,7 +125,7 @@ class Dispatcher(base.BaseDispatcher):
 
         appliance_attrs = getattr(image, "appliance_attributes")
         if appliance_attrs:
-            metadata['APPLIANCE_ATTRIBUTES'] = json.dumps(appliance_attrs)
+            metadata["APPLIANCE_ATTRIBUTES"] = json.dumps(appliance_attrs)
 
         project = kwargs.pop("project")
 
@@ -138,8 +144,11 @@ class Dispatcher(base.BaseDispatcher):
         images = list(self.client.images.list(**kwargs))
         if len(images) > 1:
             images = [img.id for img in images]
-            LOG.error("Found several images with same sha512, please remove "
-                      "them manually and run atrope again: %s", images)
+            LOG.error(
+                "Found several images with same sha512, please remove "
+                "them manually and run atrope again: %s",
+                images,
+            )
             raise exception.DuplicatedImage(images=images)
 
         try:
@@ -148,17 +157,31 @@ class Dispatcher(base.BaseDispatcher):
             glance_image = None
         else:
             if glance_image.sha512 != image.sha512:
-                LOG.warning("Image '%s' is '%s' in glance but sha512 checksums"
-                            "are different, deleting it and reuploading.",
-                            image.identifier, glance_image.id)
+                LOG.warning(
+                    "Image '%s' is '%s' in glance but sha512 checksums"
+                    "are different, deleting it and reuploading.",
+                    image.identifier,
+                    glance_image.id,
+                )
                 self.client.images.delete(glance_image.id)
                 glance_image = None
 
         metadata["disk_format"], image_fd = image.get_disk()
         metadata["disk_format"].lower()
-        if metadata["disk_format"] not in ['ami', 'ari', 'aki', 'vhd',
-                                           'vhdx', 'vmdk', 'raw', 'qcow2',
-                                           'vdi', 'iso', 'ploop', 'root-tar']:
+        if metadata["disk_format"] not in [
+            "ami",
+            "ari",
+            "aki",
+            "vhd",
+            "vhdx",
+            "vmdk",
+            "raw",
+            "qcow2",
+            "vdi",
+            "iso",
+            "ploop",
+            "root-tar",
+        ]:
             metadata["disk_format"] = "raw"
 
         if not glance_image:
@@ -170,29 +193,37 @@ class Dispatcher(base.BaseDispatcher):
             self._upload(glance_image.id, image_fd)
 
         if glance_image.status == "active":
-            LOG.info("Image '%s' stored in glance as '%s'.",
-                     image.identifier, glance_image.id)
+            LOG.info(
+                "Image '%s' stored in glance as '%s'.",
+                image.identifier,
+                glance_image.id,
+            )
 
         if metadata.get("vo", None) and project:
             try:
-                self.client.images.update(glance_image.id,
-                                          visibility="shared")
-                self.client.image_members.create(glance_image.id,
-                                                 project)
+                self.client.images.update(glance_image.id, visibility="shared")
+                self.client.image_members.create(glance_image.id, project)
             except glance_exc.HTTPConflict:
-                LOG.debug("Image '%s' already associated with VO '%s', "
-                          "tenant '%s'",
-                          image.identifier, metadata["vo"], project)
+                LOG.debug(
+                    "Image '%s' already associated with VO '%s', " "tenant '%s'",
+                    image.identifier,
+                    metadata["vo"],
+                    project,
+                )
             finally:
                 client = self._get_glance_client(project_id=project)
-                client.image_members.update(glance_image.id,
-                                            project, 'accepted')
+                client.image_members.update(glance_image.id, project, "accepted")
 
-                LOG.info("Image '%s' associated with VO '%s', project '%s'",
-                         image.identifier, metadata["vo"], project)
+                LOG.info(
+                    "Image '%s' associated with VO '%s', project '%s'",
+                    image.identifier,
+                    metadata["vo"],
+                    project,
+                )
         else:
-            LOG.error("Image '%s' does not have a project associated!" %
-                      image.identifier)
+            LOG.error(
+                "Image '%s' does not have a project associated!" % image.identifier
+            )
 
     def sync(self, image_list):
         """Sunc image list with dispached images.
@@ -206,13 +237,13 @@ class Dispatcher(base.BaseDispatcher):
                 "image_list": image_list.name,
             }
         }
-        valid_images = [i.identifier
-                        for i in image_list.get_valid_subscribed_images()]
+        valid_images = [i.identifier for i in image_list.get_valid_subscribed_images()]
         for image in self.client.images.list(**kwargs):
             appdb_id = image.get("appdb_id", "")
             if appdb_id not in valid_images:
-                LOG.warning("Glance image '%s' is not valid anymore, "
-                            "deleting it", image.id)
+                LOG.warning(
+                    "Glance image '%s' is not valid anymore, " "deleting it", image.id
+                )
                 self.client.images.delete(image.id)
 
         LOG.info("Sync terminated for image list '%s'", image_list.name)

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -24,6 +24,7 @@ from oslo_log import log
 from atrope.dispatcher import base
 from atrope import exception
 
+CONF = cfg.CONF
 CFG_GROUP = "glance"
 CONF.import_opt("prefix", "atrope.dispatcher.manager", group="dispatchers")
 opts = [

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -25,8 +25,15 @@ from atrope.dispatcher import base
 from atrope import exception
 
 CFG_GROUP = "glance"
-CONF = cfg.CONF
 CONF.import_opt("prefix", "atrope.dispatcher.manager", group="dispatchers")
+opts = [
+    cfg.ListOpt(
+        "formats",
+        default=[],
+        help="Formats to covert images to. Empty for no " "conversion.",
+    ),
+]
+CONF.register_opts(opts, group=CFG_GROUP)
 
 loading.register_auth_conf_options(CONF, CFG_GROUP)
 loading.register_session_conf_options(CONF, CFG_GROUP)
@@ -166,8 +173,8 @@ class Dispatcher(base.BaseDispatcher):
                 self.client.images.delete(glance_image.id)
                 glance_image = None
 
-        metadata["disk_format"], image_fd = image.get_disk()
-        metadata["disk_format"].lower()
+        metadata["disk_format"], image_fd = image.convert(CONF.glance.formats)
+        metadata["disk_format"] = metadata["disk_format"].lower()
         if metadata["disk_format"] not in [
             "ami",
             "ari",

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -207,8 +207,7 @@ class Dispatcher(base.BaseDispatcher):
             )
 
         if glance_image.owner == project:
-            LOG.info("Image '%s' owned by dest project %s.",
-                     image.identifier, project)
+            LOG.info("Image '%s' owned by dest project %s.", image.identifier, project)
         elif metadata.get("vo", None) and project:
             try:
                 self.client.images.update(glance_image.id, visibility="shared")

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -206,7 +206,10 @@ class Dispatcher(base.BaseDispatcher):
                 glance_image.id,
             )
 
-        if metadata.get("vo", None) and project:
+        if glance_image.owner == project:
+            LOG.info("Image '%s' owned by dest project %s.",
+                     image.identifier, project)
+        elif metadata.get("vo", None) and project:
             try:
                 self.client.images.update(glance_image.id, visibility="shared")
                 self.client.image_members.create(glance_image.id, project)

--- a/atrope/dispatcher/manager.py
+++ b/atrope/dispatcher/manager.py
@@ -76,7 +76,7 @@ class DispatcherManager(object):
         :param **kwargs: extra metadata to be added to the image.
         """
 
-        LOG.info("Preparing to dispatch list '%s''" % image_list.name)
+        LOG.info("Preparing to dispatch list '%s'" % image_list.name)
 
         kwargs.setdefault("image_list", image_list.name)
         kwargs.setdefault("project", image_list.project)

--- a/atrope/dispatcher/manager.py
+++ b/atrope/dispatcher/manager.py
@@ -19,14 +19,16 @@ from atrope import exception
 from atrope import importutils
 
 opts = [
-    cfg.MultiStrOpt('dispatcher',
-                    default=['noop'],
-                    help='Dispatcher to process images. Can be specified '
-                         'multiple times.'),
-    cfg.StrOpt('prefix',
-               default="",
-               help="If set, the image name's will be prefixed by this "
-               "option."),
+    cfg.MultiStrOpt(
+        "dispatcher",
+        default=["noop"],
+        help="Dispatcher to process images. Can be specified " "multiple times.",
+    ),
+    cfg.StrOpt(
+        "prefix",
+        default="",
+        help="If set, the image name's will be prefixed by this " "option.",
+    ),
 ]
 
 CONF = cfg.CONF
@@ -34,7 +36,7 @@ CONF.register_opts(opts, group="dispatchers")
 
 LOG = log.getLogger(__name__)
 
-DISPATCHER_NAMESPACE = 'atrope.dispatcher'
+DISPATCHER_NAMESPACE = "atrope.dispatcher"
 
 
 class DispatcherManager(object):
@@ -88,15 +90,18 @@ class DispatcherManager(object):
         try:
             images = image_list.get_valid_subscribed_images()
         except exception.ImageListNotFetched:
-            LOG.warning(f"Image list {image_list.name} has not been fetched "
-                        "skipping dispatch.")
+            LOG.warning(
+                f"Image list {image_list.name} has not been fetched "
+                "skipping dispatch."
+            )
             images = []
 
         for image in images:
-            image_name = ("%(global prefix)s%(list prefix)s%(image name)s" %
-                          {"global prefix": CONF.dispatchers.prefix,
-                           "list prefix": image_list.prefix,
-                           "image name": image.title})
+            image_name = "%(global prefix)s%(list prefix)s%(image name)s" % {
+                "global prefix": CONF.dispatchers.prefix,
+                "list prefix": image_list.prefix,
+                "image name": image.title,
+            }
             self._dispatch_image(image_name, image, is_public, **kwargs)
 
     def _dispatch_image(self, image_name, image, is_public, **kwargs):
@@ -105,6 +110,8 @@ class DispatcherManager(object):
             try:
                 dispatcher.dispatch(image_name, image, is_public, **kwargs)
             except Exception as e:
-                LOG.exception("An exception has occured when dispatching "
-                              "image %s" % image.identifier)
+                LOG.exception(
+                    "An exception has occured when dispatching "
+                    "image %s" % image.identifier
+                )
                 LOG.exception(e)

--- a/atrope/exception.py
+++ b/atrope/exception.py
@@ -33,7 +33,7 @@ class AtropeException(Exception):
             except Exception:
                 # kwargs doesn't match a variable in the message
                 # log the issue and the kwargs
-                LOG.exception('Exception in string format operation')
+                LOG.exception("Exception in string format operation")
                 for name, value in kwargs.items():
                     LOG.error("%s: %s" % (name, value))
                 message = self.msg_fmt
@@ -59,6 +59,10 @@ class ImageListDownloadFailed(AtropeException):
 
 class ImageDownloadFailed(AtropeException):
     msg_fmt = "Cannot get image, reason: (%(code)s) %(reason)s"
+
+
+class ImageConversionError(AtropeException):
+    msg_fmt = "Cannot convert image, reason: (%(code)s) %(reason)s"
 
 
 class InvalidOVAFile(AtropeException):
@@ -107,8 +111,10 @@ class DuplicatedImage(AtropeException):
 
 class ImageListSpecIsBorken(AtropeException):
     # NOTE(aloga): Borken in the class name is intentional
-    msg_fmt = ("The image list spec is broken and I am not able to "
-               "guess what the image format is.")
+    msg_fmt = (
+        "The image list spec is broken and I am not able to "
+        "guess what the image format is."
+    )
 
 
 class MetadataOverwriteNotSupported(AtropeException):

--- a/atrope/exception.py
+++ b/atrope/exception.py
@@ -57,6 +57,10 @@ class ImageListDownloadFailed(AtropeException):
     msg_fmt = "Cannot get image list, reason: (%(code)s) %(reason)s"
 
 
+class ImageExpired(AtropeException):
+    msg_fmt = "Image expired, reason: %(reason)s"
+
+
 class ImageDownloadFailed(AtropeException):
     msg_fmt = "Cannot get image, reason: (%(code)s) %(reason)s"
 

--- a/atrope/image.py
+++ b/atrope/image.py
@@ -287,3 +287,141 @@ class HepixImage(BaseImage):
 
         self.location = location
         self.locations = [location]
+
+
+class HarborImage(BaseImage):
+    """Represents an image fetched via Harbor API, downloaded via oras."""
+
+    def __init__(self, image_ref, annotations, list_name, digest):
+        """
+        Initialize HarborImage.
+
+        :param image_ref: Full image reference (e.g., registry/repo:tag) from API
+        :param annotations: Parsed OCI annotations dictionary from API response.
+        :param list_name: Name of the source list this image belongs to.
+        :param digest: SHA256 identifier of the image.
+        """
+        super(HarborImage, self).__init__(annotations)
+
+        self.image_ref = image_ref
+        self.list_name = list_name
+        self.annotations = annotations if annotations else {}
+        self.digest = digest  # SHA256 identifier of the image
+
+        self.identifier = f"{image_ref}-{digest}"
+
+        self.format = self.annotations.get("org.openstack.glance.disk_format", "raw")
+        self.container_format = self.annotations.get("org.openstack.glance.container_format", "bare")
+
+        self.sha512 = None
+
+        self.revision = self.annotations.get("org.opencontainers.image.revision")
+        self.source_url = self.annotations.get("org.opencontainers.image.source")
+        self.appliance_attributes = self.annotations
+
+        self.uri = image_ref
+        self.location = None
+        self.locations = []
+        self.verified = False
+        self.expired = False
+
+        LOG.debug(f"HarborImage initialized: {self.identifier}, format={self.format}")
+
+    def _run_oras_pull(self, command_list):
+        """Helper specifically for running oras pull command."""
+        try:
+            LOG.debug(f"Running oras command: {' '.join(command_list)}")
+            result = subprocess.run(
+                command_list,
+                capture_output=True,
+                text=True,
+                check=True,
+                encoding='utf-8'
+            )
+            LOG.debug(f"Oras pull successful. Stdout: {result.stdout[:200]}...")
+            print(result.stdout)
+            return result.stdout
+        except FileNotFoundError:
+            raise exception.AtropeException(message="oras command not found. Please ensure oras CLI is installed and in PATH.")
+        except subprocess.CalledProcessError as e:
+            raise exception.ImageDownloadFailed(code=e.returncode, reason=f"oras pull failed for {self.image_ref}: {e.stderr}")
+        except Exception as e:
+            raise exception.AtropeException(message=f"An unexpected error occurred running oras pull for {self.image_ref}: {e}")
+
+    def download(self, basedir):
+        """Download the image using oras pull."""
+        if self.expired:
+            raise exception.ImageExpired(reason="Image marked as expired")
+
+        if self.location and os.path.exists(self.location):
+            try:
+                self.verify_checksum()
+                LOG.info(f"Image {self.identifier} already downloaded and verified at {self.location}")
+                raise exception.ImageAlreadyDownloaded(location=self.location)
+            except exception.ImageVerificationFailed:
+                LOG.warning(f"Cached image {self.identifier} failed verification. Re-downloading.")
+                utils.rm(self.location)
+                self.location = None; self.locations = []; self.verified = False; self.sha512 = None
+
+        with tempfile.TemporaryDirectory(suffix=f"-{self.list_name}") as tmpdir:
+            LOG.info(f"Downloading Harbor image {self.identifier} ({self.image_ref}) using oras to {tmpdir}")
+            pull_cmd = ["oras", "pull", "--insecure", "--allow-path-traversal", self.image_ref, "-o", tmpdir]
+
+            try:
+                self._run_oras_pull(pull_cmd)
+            except exception.ImageDownloadFailed as e:
+                LOG.error(f"Failed to download {self.identifier} using oras: {e}")
+                raise
+
+            print(f"Pulled image TTTTOOOO {tmpdir}")
+
+            pulled_files = os.listdir(tmpdir)
+            if not pulled_files:
+                raise exception.ImageDownloadFailed(code=1, reason=f"oras pull to {tmpdir} resulted in no files for {self.identifier}.")
+            image_filename = max(pulled_files, key=lambda f: os.path.getsize(os.path.join(tmpdir, f)) if os.path.isfile(os.path.join(tmpdir, f)) else -1)
+            if not image_filename or not os.path.isfile(os.path.join(tmpdir, image_filename)):
+                raise exception.ImageDownloadFailed(code=1, reason=f"Could not identify main image file in oras pull output for {self.identifier} in {tmpdir}")
+
+            pulled_image_path = os.path.join(tmpdir, image_filename)
+            LOG.debug(f"Identified pulled image file: {pulled_image_path}")
+
+            safe_filename = "".join(c if c.isalnum() or c in ('-', '_', '.') else '_' for c in self.identifier.replace('/', '_').replace(':', '_'))
+            final_location = os.path.join(basedir, safe_filename)
+            utils.makedirs(basedir)
+
+            try:
+                os.rename(pulled_image_path, final_location)
+                self.location = final_location
+                self.locations = [final_location]
+                LOG.info(f"Stored Harbor image {self.identifier} at {self.location}")
+            except OSError as e:
+                raise exception.AtropeException(f"Failed to move downloaded file to cache for {self.identifier}: {e}")
+
+        try:
+            checksum_obj = utils.get_file_checksum(self.location)
+            self.sha512 = checksum_obj.hexdigest()
+            LOG.info(f"Calculated SHA512 for {self.identifier}: {self.sha512}")
+            self.verify_checksum()
+        except FileNotFoundError:
+            raise exception.ImageNotFoundOnDisk(location=self.location)
+        except exception.ImageVerificationFailed as e:
+            LOG.error(f"Immediate verification failed for {self.identifier}: {e}")
+            utils.rm(self.location)  # Clean up failed download
+            self.location = None
+            self.locations = []
+            self.verified = False
+            self.sha512 = None
+            raise
+        except Exception as e:
+            LOG.error(f"Failed to calculate or verify checksum for {self.identifier}: {e}")
+            utils.rm(self.location)  # Clean up failed download
+            self.location = None
+            self.locations = []
+            self.verified = False
+            self.sha512 = None
+            raise exception.ImageVerificationFailed(id=self.identifier, expected="N/A", obtained=f"Error during checksum: {e}")
+
+    def verify_checksum(self, location=None):
+        """Verify the image's calculated SHA512 checksum."""
+        # TODO check Harbor digest and verify based on it
+        pass

--- a/atrope/image.py
+++ b/atrope/image.py
@@ -29,15 +29,17 @@ from atrope import paths
 from atrope import utils
 
 opts = [
-    cfg.StrOpt('download_ca_file',
-               default=paths.state_path_def('atrope-ca-bundle.pem'),
-               help='Atrope will build a CA bundle for verifying the '
-                    'HTTP servers when it is downloading the image, '
-                    'concatenating the default OS CA bundle and the '
-                    'CAs present in the $ca_path directory. This '
-                    'is done as there may be certificates signed by '
-                    'CAs that are trusted by the provider, but untrusted '
-                    'by the default bundle and we need to trust both.'),
+    cfg.StrOpt(
+        "download_ca_file",
+        default=paths.state_path_def("atrope-ca-bundle.pem"),
+        help="Atrope will build a CA bundle for verifying the "
+        "HTTP servers when it is downloading the image, "
+        "concatenating the default OS CA bundle and the "
+        "CAs present in the $ca_path directory. This "
+        "is done as there may be certificates signed by "
+        "CAs that are trusted by the provider, but untrusted "
+        "by the default bundle and we need to trust both.",
+    ),
 ]
 
 CONF = cfg.CONF
@@ -97,8 +99,9 @@ class BaseImage(object):
 
     def verify_checksum(self, location=None):
         """Verify the image's checksum."""
-        LOG.info("Image '%s' present in '%s', verifying checksum",
-                 self.identifier, location)
+        LOG.info(
+            "Image '%s' present in '%s', verifying checksum", self.identifier, location
+        )
 
         location = location or self.location
         if location is None:
@@ -107,12 +110,9 @@ class BaseImage(object):
         sha512 = utils.get_file_checksum(location)
         if sha512.hexdigest() != self.sha512:
             raise exception.ImageVerificationFailed(
-                id=self.identifier,
-                expected=self.sha512,
-                obtained=sha512.hexdigest()
+                id=self.identifier, expected=self.sha512, obtained=sha512.hexdigest()
             )
-        LOG.info("Image '%s' present in '%s', checksum OK",
-                 self.identifier, location)
+        LOG.info("Image '%s' present in '%s', checksum OK", self.identifier, location)
         self.verified = True
 
 
@@ -145,9 +145,9 @@ class HepixImage(BaseImage):
 
         image_dict = image_info.get("hv:image", {})
 
-        utils.ensure_ca_bundle(CONF.download_ca_file,
-                               [requests.certs.where()],
-                               CONF.ca_path)
+        utils.ensure_ca_bundle(
+            CONF.download_ca_file, [requests.certs.where()], CONF.ca_path
+        )
 
         for i in self.required_fields:
             value = image_dict.get(i, None)
@@ -161,22 +161,30 @@ class HepixImage(BaseImage):
         self.appliance_attributes = image_dict
 
     def _download(self, location):
-        LOG.info("Downloading image '%s' from '%s' into '%s'",
-                 self.identifier, self.uri, location)
-        with open(location, 'wb') as f:
+        LOG.info(
+            "Downloading image '%s' from '%s' into '%s'",
+            self.identifier,
+            self.uri,
+            location,
+        )
+        with open(location, "wb") as f:
             try:
-                response = requests.get(self.uri, stream=True,
-                                        verify=CONF.download_ca_file)
+                response = requests.get(
+                    self.uri, stream=True, verify=CONF.download_ca_file
+                )
             except Exception as e:
                 LOG.error(e)
-                raise exception.ImageDownloadFailed(code=e.errno,
-                                                    reason=e)
+                raise exception.ImageDownloadFailed(code=e.errno, reason=e)
 
             if not response.ok:
-                LOG.error("Cannot download image: (%s) %s",
-                          response.status_code, response.reason)
-                raise exception.ImageDownloadFailed(code=response.status_code,
-                                                    reason=response.reason)
+                LOG.error(
+                    "Cannot download image: (%s) %s",
+                    response.status_code,
+                    response.reason,
+                )
+                raise exception.ImageDownloadFailed(
+                    code=response.status_code, reason=response.reason
+                )
 
             for block in response.iter_content(1024):
                 if block:
@@ -188,8 +196,7 @@ class HepixImage(BaseImage):
             LOG.error(e)
             raise
         else:
-            LOG.info("Image '%s' stored as '%s'",
-                     self.identifier, location)
+            LOG.info("Image '%s' stored as '%s'", self.identifier, location)
 
     def download(self, basedir):
         # The image has been already downloaded in this execution.
@@ -205,9 +212,11 @@ class HepixImage(BaseImage):
             try:
                 self.verify_checksum(location=location)
             except exception.ImageVerificationFailed:
-                LOG.warning("Image '%s' present in '%s' is not valid, "
-                            "downloading again",
-                            self.identifier, location)
+                LOG.warning(
+                    "Image '%s' present in '%s' is not valid, " "downloading again",
+                    self.identifier,
+                    location,
+                )
                 self._download(location)
 
         self.location = location

--- a/atrope/image_list/harbor.py
+++ b/atrope/image_list/harbor.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+
+# (Include Apache License Header Here)
+
+import json
+import pprint
+import requests
+import re
+from urllib.parse import quote_plus
+
+from oslo_config import cfg
+from oslo_log import log
+
+from atrope import exception, utils
+from atrope.image_list import source
+from atrope import image
+
+LOG = log.getLogger(__name__)
+CONF = cfg.CONF
+
+# Add any Harbor specific config options if needed via CONF.register_opts
+
+
+class HarborImageListSource(source.BaseImageListSource):
+    """An image list source fetching metadata via Harbor API, downloading via oras."""
+
+    def __init__(
+        self,
+        name,
+        api_url="",        # https://harbor.example.com/api/v2.0
+        registry_host="",  # harbor.example.com (needed for oras pull)
+        enabled=True,
+        subscribed_images=[],
+        prefix="",
+        project="",
+        tag_pattern=None,
+        auth_user=None,
+        auth_password=None,
+        # auth_token=None,
+        verify_ssl=True,
+        page_size=50,
+        **kwargs,
+    ):
+        super(HarborImageListSource, self).__init__(
+            name,
+            url=f"{api_url}/projects/{project}/repositories",
+            enabled=enabled,
+            subscribed_images=subscribed_images,
+            prefix=prefix,
+            project=project,
+        )
+        self.api_url = api_url.rstrip('/')
+        self.registry_host = registry_host or self.api_url.split('//', 1)[-1].split('/', 1)[0]
+        self.tag_pattern_re = re.compile(tag_pattern) if tag_pattern else None
+        self.auth_user = auth_user
+        self.auth_password = auth_password
+        # self.auth_token = auth_token
+        self.verify_ssl = verify_ssl
+        self.page_size = page_size
+        self.image_list = []
+        self.error = None
+        self._session = None
+        self.endorser = kwargs.get("endorser", {})
+
+        # CHANGE THIS LATER
+        self.trusted = True
+        self.verified = True
+        self.expired = False
+
+        if not self.registry_host:
+            raise ValueError(f"registry_host must be provided for Harbor source {name}")
+
+    def _get_session(self):
+        """Initialize requests session with authentication."""
+        if self._session is None:
+            self._session = requests.Session()
+            if self.auth_user and self.auth_password:
+                self._session.auth = (self.auth_user, self.auth_password)
+            elif self.auth_token:
+                self._session.headers.update({"Authorization": self.auth_token})
+            else:
+                LOG.warning(f"No authentication configured for Harbor source {self.name}")
+            self._session.verify = self.verify_ssl
+            if not self.verify_ssl:
+                requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
+        return self._session
+
+    def _set_error(func):
+        def decorated(self):
+            try:
+                func(self)
+            except Exception as e:
+                self.error = e
+                LOG.error(f"Failed to fetch Harbor list '{self.name}': {e}", exc_info=True)
+        return decorated
+
+    def _fetch_paginated_data(self, url, params=None):
+        """Helper to fetch data from a paginated Harbor API endpoint."""
+        session = self._get_session()
+        results = []
+        page = 1
+        current_url = url
+
+        while current_url:
+            current_params = params.copy() if params else {}
+            current_params['page'] = page
+            current_params['page_size'] = self.page_size
+
+            try:
+                LOG.debug(f"Fetching page {page} from {current_url} with params {current_params}")
+                response = session.get(current_url, params=current_params)
+                response.raise_for_status()
+                data = response.json()
+                if not data:
+                    LOG.debug(f"No more data found for {current_url} on page {page}.")
+                    break
+                results.extend(data)
+
+                link_header = response.headers.get('Link')
+                next_url = None
+                if link_header:
+                    links = requests.utils.parse_header_links(link_header)
+                    for link in links:
+                        if link.get('rel') == 'next':
+                            next_url = link.get('url')
+                            LOG.debug(f"Found next page link: {next_url}")
+                            break
+                current_url = next_url
+                page += 1
+
+            except requests.exceptions.RequestException as e:
+                status_code = e.response.status_code if e.response else 0
+                msg = f"Harbor API request failed for {self.name} accessing {current_url}: {e}"
+                LOG.error(msg)
+                self.error = exception.ImageListDownloadFailed(code=status_code, reason=msg)
+                return None
+
+        return results
+
+    def _list_repositories_in_project(self):
+        """Lists repositories within the configured project."""
+        repos_url = f"{self.api_url}/projects/{self.project}/repositories"
+        LOG.debug(f"Listing repositories from: {repos_url}")
+        repositories = self._fetch_paginated_data(repos_url)
+
+        if repositories is None:
+            LOG.error(f"Failed to list repositories for project {self.project}. See previous errors.")
+            return None
+        if not repositories:
+            LOG.warning(f"No repositories found in project '{self.project}' for source '{self.name}'.")
+            return []
+
+        LOG.info(f"Found {len(repositories)} repositories in project '{self.project}'.")
+        return repositories
+
+    def _process_artifact(self, artifact, repo_name):
+        """Processes a single artifact dictionary, checking tags and filters."""
+        if not artifact.get("tags"):
+            LOG.debug(f"Artifact {artifact.get('digest')} in repo {repo_name} has no tags, skipping.")
+            return
+
+        processed_artifact_tags = set()
+        for tag_info in artifact.get("tags", []):
+            tag_name = tag_info.get("name")
+            if not tag_name or tag_name in processed_artifact_tags:
+                continue
+
+            process_this_tag = False
+            if self.subscribed_images:
+                if tag_name in self.subscribed_images or artifact.get("digest") in self.subscribed_images:
+                    process_this_tag = True
+            elif self.tag_pattern_re:
+                if self.tag_pattern_re.match(tag_name):
+                    process_this_tag = True
+            elif not self.subscribed_images and not self.tag_pattern_re:
+                process_this_tag = True
+
+            if process_this_tag:
+                try:
+                    image_ref = f"{self.registry_host}/{repo_name}:{tag_name}"
+                    print(repo_name)
+                    annotations = artifact.get("extra_attrs", {}).get("annotations", {})
+                    digest = artifact.get("digest", "")
+                    if not annotations and "annotations" in artifact:
+                        annotations = artifact.get("annotations", {})
+
+                    if not annotations:
+                        LOG.warning(f"No annotations found for {image_ref} in API list response.")
+
+                    img = image.HarborImage(image_ref, annotations, self.name, digest)
+                    self.image_list.append(img)
+                    processed_artifact_tags.add(tag_name)
+                    LOG.debug(f"Added Harbor image from API: {image_ref}")
+
+                except Exception as e:
+                    LOG.error(f"Failed to process artifact tag {repo_name}:{tag_name}: {e}", exc_info=True)
+
+    def _process_repository(self, repo_info):
+        """Fetches and processes artifacts for a given repository."""
+        repo_name = repo_info.get("name")
+        if '/' in repo_name:
+            repo_name_only = repo_name.split('/', 1)[1]
+        else:
+            repo_name_only = repo_name
+
+        if not repo_name_only:
+            LOG.warning(f"Could not extract repository name from '{repo_name}', skipping.")
+            return
+
+        encoded_repo_name = quote_plus(repo_name_only)
+        artifacts_url = f"{self.api_url}/projects/{self.project}/repositories/{encoded_repo_name}/artifacts"
+        LOG.debug(f"Listing artifacts for repository '{repo_name}' from {artifacts_url}")
+
+        artifacts = self._fetch_paginated_data(artifacts_url, params={'with_tag': 'true', 'with_scan_overview': 'false', 'with_label': 'false'})
+
+        if artifacts is None:
+            LOG.error(f"Failed to list artifacts for repository '{repo_name}'. Skipping this repository.")
+            return
+
+        if not artifacts:
+            LOG.debug(f"No artifacts found in repository '{repo_name}'.")
+            return
+
+        LOG.debug(f"Processing {len(artifacts)} artifacts for repository '{repo_name}'")
+        for artifact in artifacts:
+            self._process_artifact(artifact, repo_name)
+
+    @_set_error
+    def fetch(self):
+        if not self.enabled or not self.api_url or not self.project:
+            LOG.info(f"Harbor source '{self.name}' disabled or config incomplete, skipping fetch.")
+            return
+
+        LOG.info(f"Fetching images via Harbor API for project: {self.name} ({self.project})")
+        self.image_list = []
+        self.error = None
+
+        repositories = self._list_repositories_in_project()
+        if repositories is None or not repositories:
+            return
+
+        for repo_info in repositories:
+            self._process_repository(repo_info)
+
+        LOG.info(f"Finished fetching Harbor source '{self.name}'. Found {len(self.image_list)} matching images across all repositories in project '{self.project}'.")
+
+    def print_list(self, contents=False):
+        d = {
+            "name": self.name,
+            "url": self.url,
+            "enabled": self.enabled,
+            "project": self.project,
+            "registry_host": self.registry_host,
+            "endorser": self.endorser,
+        }
+
+        if self.error is not None:
+            d["error"] = str(self.error)
+
+        try:
+            images = [str(img.identifier) for img in (self.image_list or [])]
+        except exception.ImageListNotFetched:
+            images = None
+
+        d["images found"] = images if images else "None"
+
+        subscribed_cfg = self.subscribed_images if self.subscribed_images else "All (or by pattern)"
+        d["images (subscribed config)"] = subscribed_cfg
+        if self.tag_pattern_re:
+            d["tag_pattern"] = self.tag_pattern_re.pattern
+
+        utils.print_dict(d)
+
+    def get_subscribed_images(self):
+        """Get the subscribed images from the fetched image list."""
+        if not self.enabled:
+            return []
+
+        if self.image_list is None:
+            LOG.error(f"Image list {self.name} has not been fetched!")
+            return []
+
+        if not self.subscribed_images:
+            return self.image_list
+        else:
+            return [
+                img
+                for img in self.image_list
+                if img.identifier in self.subscribed_images
+            ]
+
+    def get_images(self):
+        """Get the images defined in the fetched image list."""
+        if not self.enabled:
+            return []
+
+        if self.image_list is None:
+            raise exception.ImageListNotFetched(id=self.name)
+
+        return self.image_list

--- a/atrope/image_list/hepix.py
+++ b/atrope/image_list/hepix.py
@@ -32,9 +32,11 @@ from atrope import smime
 from atrope import utils
 
 opts = [
-    cfg.StrOpt('hepix_sources',
-               default='/etc/atrope/hepix.yaml',
-               help='Where the HEPiX image list sources are stored.'),
+    cfg.StrOpt(
+        "hepix_sources",
+        default="/etc/atrope/hepix.yaml",
+        help="Where the HEPiX image list sources are stored.",
+    ),
 ]
 
 CONF = cfg.CONF
@@ -49,6 +51,7 @@ class HepixImageList(object):
     Objects of this class will hold the representation of the
     downloaded Hepix image list.
     """
+
     required_fields = (
         "dc:date:created",
         "dc:date:expires",
@@ -85,7 +88,7 @@ class HepixImageList(object):
         for img_meta in meta.get("hv:images"):
             self.images.append(image.HepixImage(img_meta))
 
-        self.vo = meta.get('ad:vo', None)
+        self.vo = meta.get("ad:vo", None)
 
     def get_images(self):
         return self.images
@@ -94,8 +97,16 @@ class HepixImageList(object):
 class HepixImageListSource(source.BaseImageListSource):
     """An image list."""
 
-    def __init__(self, name, url="", enabled=True, subscribed_images=[],
-                 prefix="", project="", **kwargs):
+    def __init__(
+        self,
+        name,
+        url="",
+        enabled=True,
+        subscribed_images=[],
+        prefix="",
+        project="",
+        **kwargs
+    ):
 
         super(HepixImageListSource, self).__init__(
             name,
@@ -103,7 +114,7 @@ class HepixImageListSource(source.BaseImageListSource):
             enabled=enabled,
             subscribed_images=subscribed_images,
             prefix=prefix,
-            project=project
+            project=project,
         )
 
         self.token = kwargs.get("token", "")
@@ -127,6 +138,7 @@ class HepixImageListSource(source.BaseImageListSource):
             except Exception as e:
                 self.error = e
                 raise
+
         return decorated
 
     @_set_error
@@ -156,13 +168,14 @@ class HepixImageListSource(source.BaseImageListSource):
                  the image.
         """
         if self.token:
-            auth = (self.token, 'x-oauth-basic')
+            auth = (self.token, "x-oauth-basic")
         else:
             auth = None
         response = requests.get(self.url, auth=auth)
         if response.status_code != 200:
-            raise exception.ImageListDownloadFailed(code=response.status_code,
-                                                    reason=response.reason)
+            raise exception.ImageListDownloadFailed(
+                code=response.status_code, reason=response.reason
+            )
         else:
             return response.content
 
@@ -189,18 +202,25 @@ class HepixImageListSource(source.BaseImageListSource):
 
         list_endorser = self.image_list.endorser
         msg = None
-        if (self.signer.dn != list_endorser.dn or
-                self.signer.ca != list_endorser.ca):
-            msg = ("List '%s' signer != list endorser "
-                   "'%s' != '%s'" %
-                   (self.name, self.signer, list_endorser))
+        if self.signer.dn != list_endorser.dn or self.signer.ca != list_endorser.ca:
+            msg = "List '%s' signer != list endorser " "'%s' != '%s'" % (
+                self.name,
+                self.signer,
+                list_endorser,
+            )
         elif self.endorser["dn"] != list_endorser.dn:
-            msg = ("List '%s' endorser is not trusted, DN mismatch "
-                   "'%s' != '%s'" %
-                   self.name, self.endorser["dn"], list_endorser.dn)
+            msg = (
+                "List '%s' endorser is not trusted, DN mismatch "
+                "'%s' != '%s'" % self.name,
+                self.endorser["dn"],
+                list_endorser.dn,
+            )
         elif self.endorser["ca"] != list_endorser.ca:
-            msg = ("List '%s' endorser CA is invalid '%s' != '%s'" %
-                   self.name, self.endorser["ca"], list_endorser.ca)
+            msg = (
+                "List '%s' endorser CA is invalid '%s' != '%s'" % self.name,
+                self.endorser["ca"],
+                list_endorser.ca,
+            )
         if msg:
             LOG.error(msg)
             self.error = msg
@@ -210,8 +230,7 @@ class HepixImageListSource(source.BaseImageListSource):
     def _check_expiry(self):
         now = datetime.datetime.now(dateutil.tz.tzlocal())
         if self.image_list.expires < now:
-            LOG.warning("List '%s' expired on '%s'",
-                        self.name, self.image_list.expires)
+            LOG.warning("List '%s' expired on '%s'", self.name, self.image_list.expires)
             return True
         return False
 

--- a/atrope/image_list/hepix.py
+++ b/atrope/image_list/hepix.py
@@ -107,7 +107,6 @@ class HepixImageListSource(source.BaseImageListSource):
         project="",
         **kwargs
     ):
-
         super(HepixImageListSource, self).__init__(
             name,
             url=url,

--- a/atrope/image_list/manager.py
+++ b/atrope/image_list/manager.py
@@ -60,10 +60,10 @@ class BaseImageListManager(object):
         try:
             lst.fetch()
         except exception.AtropeException as e:
-            LOG.error("Error loading list '%s' from '%s', reason: %s",
-                      lst.name, lst.url, e)
-            LOG.debug("Exception while downloading list '%s'",
-                      lst.name, exc_info=e)
+            LOG.error(
+                "Error loading list '%s' from '%s', reason: %s", lst.name, lst.url, e
+            )
+            LOG.debug("Exception while downloading list '%s'", lst.name, exc_info=e)
         return lst
 
     def add_image_list_source(self, image_list, force=False):
@@ -120,8 +120,9 @@ class YamlImageListManager(BaseImageListManager):
             with open(CONF.sources.hepix_sources, "rb") as f:
                 image_lists = yaml.safe_load(f) or {}
         except IOError as e:
-            raise exception.CannotOpenFile(file=CONF.sources.hepix_sources,
-                                           errno=e.errno)
+            raise exception.CannotOpenFile(
+                file=CONF.sources.hepix_sources, errno=e.errno
+            )
 
         for name, list_meta in image_lists.items():
             lst = atrope.image_list.hepix.HepixImageListSource(
@@ -131,5 +132,6 @@ class YamlImageListManager(BaseImageListManager):
                 subscribed_images=list_meta.pop("images", []),
                 prefix=list_meta.pop("prefix", ""),
                 project=list_meta.pop("project", ""),
-                **list_meta)
+                **list_meta
+            )
             self.lists[name] = lst

--- a/atrope/image_list/source.py
+++ b/atrope/image_list/source.py
@@ -28,8 +28,16 @@ LOG = log.getLogger(__name__)
 class BaseImageListSource(object):
     """An image list."""
 
-    def __init__(self, name, url="", enabled=True, subscribed_images=[],
-                 prefix="", project="", **kwargs):
+    def __init__(
+        self,
+        name,
+        url="",
+        enabled=True,
+        subscribed_images=[],
+        prefix="",
+        project="",
+        **kwargs,
+    ):
         self.name = name
         self.url = url
         self.enabled = enabled
@@ -39,10 +47,7 @@ class BaseImageListSource(object):
         self.project = project
 
     def __repr__(self):
-        return "<%s: %s>" % (
-            self.__class__.__name__,
-            self.name
-        )
+        return "<%s: %s>" % (self.__class__.__name__, self.name)
 
     @abc.abstractmethod
     def fetch(self):
@@ -63,8 +68,11 @@ class BaseImageListSource(object):
         if not self.subscribed_images:
             return self.image_list.get_images()
         else:
-            return [img for img in self.image_list.get_images()
-                    if img.identifier in self.subscribed_images]
+            return [
+                img
+                for img in self.image_list.get_images()
+                if img.identifier in self.subscribed_images
+            ]
 
     def get_images(self):
         """Get the images defined in the fetched image list."""

--- a/atrope/image_list/source.py
+++ b/atrope/image_list/source.py
@@ -54,7 +54,7 @@ class BaseImageListSource(object):
         """Fetch the image list."""
 
     def get_valid_subscribed_images(self):
-        return [i for i in self.get_subscribed_images() if i.verified]
+        return [i for i in self.get_subscribed_images() if i.verified and not i.expired]
 
     def get_subscribed_images(self):
         """Get the subscribed images from the fetched image list."""

--- a/atrope/importutils.py
+++ b/atrope/importutils.py
@@ -23,14 +23,15 @@ import traceback
 
 def import_class(import_str):
     """Returns a class from a string including module and class."""
-    mod_str, _sep, class_str = import_str.rpartition('.')
+    mod_str, _sep, class_str = import_str.rpartition(".")
     try:
         __import__(mod_str)
         return getattr(sys.modules[mod_str], class_str)
     except (ValueError, AttributeError):
-        raise ImportError('Class %s cannot be found (%s)' %
-                          (class_str,
-                           traceback.format_exception(*sys.exc_info())))
+        raise ImportError(
+            "Class %s cannot be found (%s)"
+            % (class_str, traceback.format_exception(*sys.exc_info()))
+        )
 
 
 def import_object(import_str, *args, **kwargs):

--- a/atrope/opts.py
+++ b/atrope/opts.py
@@ -27,12 +27,12 @@ import atrope.smime
 
 def list_opts():
     return [
-        ('DEFAULT', itertools.chain(atrope.image.opts,
-                                    atrope.paths.opts,
-                                    atrope.smime.opts)
-         ),
-        ('cache', atrope.cache.opts),
-        ('sources', atrope.image_list.hepix.opts),
-        ('dispatcher', atrope.dispatcher.manager.opts),
-        ('glance', atrope.dispatcher.glance.opts),
+        (
+            "DEFAULT",
+            itertools.chain(atrope.image.opts, atrope.paths.opts, atrope.smime.opts),
+        ),
+        ("cache", atrope.cache.opts),
+        ("sources", atrope.image_list.hepix.opts),
+        ("dispatcher", atrope.dispatcher.manager.opts),
+        ("glance", atrope.dispatcher.glance.opts),
     ]

--- a/atrope/ovf.py
+++ b/atrope/ovf.py
@@ -21,8 +21,8 @@ from lxml import etree
 from atrope import exception
 
 SPECS = {
-    'http://www.vmware.com/interfaces/specifications/vmdk.html': 'vmdk',
-    'https://people.gnome.org/~markmc/qcow-image-format.html': 'qcow',
+    "http://www.vmware.com/interfaces/specifications/vmdk.html": "vmdk",
+    "https://people.gnome.org/~markmc/qcow-image-format.html": "qcow",
 }
 
 
@@ -42,18 +42,20 @@ def extract_file(ova, filename):
 def get_disk_name(ovf):
     """Get the disk format and file name from a OVF descriptor."""
     root = etree.fromstring(ovf)
-    ovf_ns = root.nsmap['ovf']
+    ovf_ns = root.nsmap["ovf"]
 
-    id_attr = '{%s}id' % ovf_ns
-    href_attr = '{%s}href' % ovf_ns
-    files = {f.get(id_attr): f.get(href_attr) for f in
-             root.findall('ovf:References/ovf:File', root.nsmap)}
+    id_attr = "{%s}id" % ovf_ns
+    href_attr = "{%s}href" % ovf_ns
+    files = {
+        f.get(id_attr): f.get(href_attr)
+        for f in root.findall("ovf:References/ovf:File", root.nsmap)
+    }
 
     # we do not care about more than one disk
-    disk = root.find('ovf:DiskSection/ovf:Disk', root.nsmap)
+    disk = root.find("ovf:DiskSection/ovf:Disk", root.nsmap)
     if disk is not None:
-        format_attr = '{%s}format' % ovf_ns
-        fileref_attr = '{%s}fileRef' % ovf_ns
+        format_attr = "{%s}format" % ovf_ns
+        fileref_attr = "{%s}fileRef" % ovf_ns
         ovf_format = disk.get(format_attr)
         if not ovf_format:
             raise Exception("Expecting some format!")

--- a/atrope/paths.py
+++ b/atrope/paths.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 
 # Copyright 2010 United States Government as represented by the
@@ -24,13 +23,16 @@ import os
 from oslo_config import cfg
 
 opts = [
-    cfg.StrOpt('basedir',
-               default=os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                    '../')),
-               help='Directory where the atrope python module is installed'),
-    cfg.StrOpt('state_path',
-               default='$basedir',
-               help="Top-level directory for maintaining atrope's state"),
+    cfg.StrOpt(
+        "basedir",
+        default=os.path.abspath(os.path.join(os.path.dirname(__file__), "../")),
+        help="Directory where the atrope python module is installed",
+    ),
+    cfg.StrOpt(
+        "state_path",
+        default="$basedir",
+        help="Top-level directory for maintaining atrope's state",
+    ),
 ]
 
 CONF = cfg.CONF
@@ -39,4 +41,4 @@ CONF.register_opts(opts)
 
 def state_path_def(*args):
     """Return an uninterpolated path relative to $state_path."""
-    return os.path.join('$state_path', *args)
+    return os.path.join("$state_path", *args)

--- a/atrope/tests/base.py
+++ b/atrope/tests/base.py
@@ -20,7 +20,7 @@ import os
 import fixtures
 import testtools
 
-_TRUE_VALUES = ('True', 'true', '1', 'yes')
+_TRUE_VALUES = ("True", "true", "1", "yes")
 
 
 class TestCase(testtools.TestCase):
@@ -31,7 +31,7 @@ class TestCase(testtools.TestCase):
         """Run before each test method to initialize test environment."""
 
         super(TestCase, self).setUp()
-        test_timeout = os.environ.get('OS_TEST_TIMEOUT', 0)
+        test_timeout = os.environ.get("OS_TEST_TIMEOUT", 0)
         try:
             test_timeout = int(test_timeout)
         except ValueError:
@@ -43,11 +43,11 @@ class TestCase(testtools.TestCase):
         self.useFixture(fixtures.NestedTempfile())
         self.useFixture(fixtures.TempHomeDir())
 
-        if os.environ.get('OS_STDOUT_CAPTURE') in _TRUE_VALUES:
-            stdout = self.useFixture(fixtures.StringStream('stdout')).stream
-            self.useFixture(fixtures.MonkeyPatch('sys.stdout', stdout))
-        if os.environ.get('OS_STDERR_CAPTURE') in _TRUE_VALUES:
-            stderr = self.useFixture(fixtures.StringStream('stderr')).stream
-            self.useFixture(fixtures.MonkeyPatch('sys.stderr', stderr))
+        if os.environ.get("OS_STDOUT_CAPTURE") in _TRUE_VALUES:
+            stdout = self.useFixture(fixtures.StringStream("stdout")).stream
+            self.useFixture(fixtures.MonkeyPatch("sys.stdout", stdout))
+        if os.environ.get("OS_STDERR_CAPTURE") in _TRUE_VALUES:
+            stderr = self.useFixture(fixtures.StringStream("stderr")).stream
+            self.useFixture(fixtures.MonkeyPatch("sys.stderr", stderr))
 
         self.log_fixture = self.useFixture(fixtures.FakeLogger())

--- a/atrope/tests/test_atrope.py
+++ b/atrope/tests/test_atrope.py
@@ -23,6 +23,5 @@ from atrope.tests import base
 
 
 class TestAtrope(base.TestCase):
-
     def test_something(self):
         pass

--- a/atrope/utils.py
+++ b/atrope/utils.py
@@ -27,7 +27,7 @@ from six.moves import input
 
 def print_list(objs, fields, sortby=None):
     pt = prettytable.PrettyTable([f for f in fields], caching=False)
-    pt.align = 'l'
+    pt.align = "l"
     for o in objs:
         row = []
         for field in fields:
@@ -40,19 +40,19 @@ def print_list(objs, fields, sortby=None):
 
 def print_dict(d, dict_property="Property", dict_value="Value", wrap=0):
     pt = prettytable.PrettyTable([dict_property, dict_value], caching=False)
-    pt.align = 'l'
+    pt.align = "l"
     for k, v in sorted(d.items()):
         # if value has a newline, add in multiple rows
         # e.g. fault with stacktrace
-        if v and isinstance(v, six.string_types) and r'\n' in v:
-            lines = v.strip().split(r'\n')
+        if v and isinstance(v, six.string_types) and r"\n" in v:
+            lines = v.strip().split(r"\n")
             col1 = k
             for line in lines:
                 pt.add_row([col1, line])
-                col1 = ''
+                col1 = ""
         else:
             if v is None:
-                v = '-'
+                v = "-"
             pt.add_row([k, v])
 
     result = pt.get_string()
@@ -136,14 +136,16 @@ def run_once(f):
         if not wrapper.has_run:
             wrapper.has_run = True
             return f(*args, **kwargs)
+
     wrapper.has_run = False
     return wrapper
 
 
 @run_once
 def ensure_ca_bundle(dest, ca_files, ca_dir):
-    ca_files.extend([os.path.join(ca_dir, f) for f in os.listdir(ca_dir)
-                     if f.endswith(".pem")])
+    ca_files.extend(
+        [os.path.join(ca_dir, f) for f in os.listdir(ca_dir) if f.endswith(".pem")]
+    )
     with open(dest, "w") as f:
         for cafile in ca_files:
             with open(cafile) as ca:

--- a/etc/hepix.yaml.sample
+++ b/etc/hepix.yaml.sample
@@ -1,6 +1,6 @@
 ttycorelinux egi:
     url: https://vmcaster.appdb.egi.eu/store/vappliance/tinycorelinux/image.list
-    enabled: true
+    enabled: false
     endorser:
         dn: '/DC=EU/DC=EGI/C=NL/O=Hosts/O=EGI.eu/CN=appdb.egi.eu'
         ca: "/DC=ORG/DC=SEE-GRID/CN=SEE-GRID CA 2013"
@@ -8,7 +8,7 @@ ttycorelinux egi:
 
 vo.fedcloud.egi.eu:
     url: https://vmcaster.appdb.egi.eu/store/vo/fedcloud.egi.eu/image.list
-    enabled: true
+    enabled: false
     endorser:
         dn: '/DC=EU/DC=EGI/C=NL/O=Hosts/O=EGI.eu/CN=appdb.egi.eu'
         ca: "/DC=ORG/DC=SEE-GRID/CN=SEE-GRID CA 2013"
@@ -18,8 +18,27 @@ vo.fedcloud.egi.eu:
     prefix: "FEDCLOUD "
     project: bb02bda767b4490a82b2f62f9347a0f5
 
-foo:
+local_list:
     enabled: false
+    file_path: /home/user/Downloads/image.list.txt  # Path to the MIME file
+    endorser:
+        dn: '/DC=EU/DC=EGI/C=NL/O=Hosts/O=EGI.eu/CN=appdb.egi.eu'
+        ca: "/DC=ORG/DC=SEE-GRID/CN=SEE-GRID CA 2013"
+    images: []
+
+harbor:
+    enabled: true
+    type: harbor
+    api_url: "http://harbor.adress/api/v2.0"
+    project: "myproject"
+    registry_host: "harbor.adress"
+    auth_user: "user"             
+    auth_password: "password"
+    images: []
+    prefix: "HARBOR "
+    verify_ssl: false
+    page_size: 30
+    endorser:
 
 bar:
     enabled: false

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,4 @@
 # THIS FILE IS MANAGED BY THE GLOBAL REQUIREMENTS REPO - DO NOT EDIT
 import setuptools
 
-setuptools.setup(
-    setup_requires=['pbr'],
-    pbr=True)
+setuptools.setup(setup_requires=["pbr"], pbr=True)


### PR DESCRIPTION
# Summary

Add Harbor Registry as an Image List Source
New Source Type: Adds type: harbor to the YAML configuration to define Harbor repositories as image sources.   
Harbor API: Uses the Harbor API v2 to list artifacts and fetch their metadata (including OCI annotations) from specified repositories.
<WIP> Oras CLI for downloading images: use the oras CLI tool, but now only for downloading the images.
configuration: Introduces new YAML configuration options for Harbor sources, including api_url, repository, registry_host, and authentication details (user/password or token).
Includes new HarborImageListSource and HarborImage classes, alongside modifications to YamlImageListManager to recognize and load the new source type.

This allows atrope to fetch, cache, and potentially dispatch artifacts stored in Harbor, extending its synchronization capabilities beyond the existing HEPiX source type


