### PR TITLE
Glance deactivate unshare images

### DIFF
--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -285,7 +285,8 @@ class Dispatcher(base.BaseDispatcher):
                         LOG.debug("Set image '%s' as shared", image.identifier)
                         self.client.image.update_image(glance_image.id, visibility="shared")
                     self._share_image(vo=vo, image=image, glance_image=glance_image, project=project)
-            self._clean_stale_memberships(glance_image.id, vos)
+            if glance_image.visibility == "shared":
+                self._clean_stale_memberships(glance_image.id, vos)
 
     def sync(self, image_list):
         """Sync image list with dispatched images.

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -48,9 +48,9 @@ opts = [
         default="shared",
         choices=["shared", "community"],
         help="The sharing model to use for images. 'shared' will use "
-             "Glance image members to share with specific projects. "
-             "'community' will set the image visibility to community, "
-             "making it available to all projects.",
+        "Glance image members to share with specific projects. "
+        "'community' will set the image visibility to community, "
+        "making it available to all projects.",
     ),
 ]
 CONF.register_opts(opts, group=CFG_GROUP)
@@ -123,7 +123,7 @@ class Dispatcher(base.BaseDispatcher):
         except IOError as e:
             raise exception.CannotOpenFile(file=CONF.glance.vo_map, errno=e.errno)
         return vo_map
-    
+
     def _clean_stale_memberships(self, image_id, vos, visibility):
         self.client.image.update_image(image_id, visibility="shared")
         current_projects = {self.vo_map.get(vo, {}).get("project_id", "") for vo in vos}
@@ -132,10 +132,10 @@ class Dispatcher(base.BaseDispatcher):
             if member.member_id not in current_projects:
                 self.client.image.remove_member(image_id, member.member_id)
                 LOG.info(
-                        "Image '%s' not associated with project '%s' anymore, stopped sharing",
-                        image_id,
-                        member.member_id,
-                    )
+                    "Image '%s' not associated with project '%s' anymore, stopped sharing",
+                    image_id,
+                    member.member_id,
+                )
         self.client.image.update_image(image_id, visibility=visibility)
 
     def _share_image(self, image, glance_image, project):
@@ -151,7 +151,7 @@ class Dispatcher(base.BaseDispatcher):
             client = self._get_openstack_client(project_id=project)
             client.image.update_member(
                 member=project, image=glance_image.id, status="accepted"
-                )
+            )
 
             LOG.info(
                 "Image '%s' associated with project '%s'",
@@ -169,9 +169,9 @@ class Dispatcher(base.BaseDispatcher):
 
         vos = kwargs.pop("vos")
 
-        if CONF.glance.sharing_model == 'community':
+        if CONF.glance.sharing_model == "community":
             visibility = "community"
-        elif CONF.glance.sharing_model == 'shared' and vos:
+        elif CONF.glance.sharing_model == "shared" and vos:
             visibility = "shared"
         else:
             visibility = "public" if is_public else "private"
@@ -261,16 +261,15 @@ class Dispatcher(base.BaseDispatcher):
 
         if glance_image.status == "active":
             if glance_image.visibility != visibility:
-                        LOG.info("Set image '%s' as '%s'", image.identifier, visibility)
-                        self.client.image.update_image(glance_image.id, visibility=visibility)
+                LOG.info("Set image '%s' as '%s'", image.identifier, visibility)
+                self.client.image.update_image(glance_image.id, visibility=visibility)
             LOG.info(
                 "Image '%s' stored in glance as '%s'.",
                 image.identifier,
                 glance_image.id,
             )
 
-
-        if CONF.glance.sharing_model == 'shared':
+        if CONF.glance.sharing_model == "shared":
             for vo in vos:
                 project = self.vo_map.get(vo, {}).get("project_id", "")
                 if not project:
@@ -280,15 +279,21 @@ class Dispatcher(base.BaseDispatcher):
                     continue
                 if glance_image.owner == project:
                     LOG.info(
-                        "Image '%s' owned by dest project %s.", image.identifier, project
+                        "Image '%s' owned by dest project %s.",
+                        image.identifier,
+                        project,
                     )
                 else:
                     if glance_image.visibility != "shared":
                         LOG.debug("Set image '%s' as shared", image.identifier)
                         visibility = "shared"
-                        self.client.image.update_image(glance_image.id, visibility="shared")
-                    self._share_image(vo=vo, image=image, glance_image=glance_image, project=project)
-            
+                        self.client.image.update_image(
+                            glance_image.id, visibility="shared"
+                        )
+                    self._share_image(
+                        vo=vo, image=image, glance_image=glance_image, project=project
+                    )
+
             self._clean_stale_memberships(glance_image.id, vos, visibility)
 
     def sync(self, image_list):
@@ -313,7 +318,8 @@ class Dispatcher(base.BaseDispatcher):
                     LOG.warning(
                         "Failed to delete Glance image '%s': %s. "
                         "Making it private and deactivating it instead.",
-                        image.id, e
+                        image.id,
+                        e,
                     )
                     self.client.image.update_image(image.id, visibility="private")
                     self.client.image.deactivate_image(image.id)

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -138,14 +138,13 @@ class Dispatcher(base.BaseDispatcher):
                     )
         self.client.image.update_image(image_id, visibility=visibility)
 
-    def _share_image(self, vo, image, glance_image, project):
+    def _share_image(self, image, glance_image, project):
         try:
             self.client.image.add_member(glance_image.id, member_id=project)
         except ConflictException:
             LOG.debug(
-                "Image '%s' already associated with VO '%s', " "tenant '%s'",
+                "Image '%s' already associated with project '%s'",
                 image.identifier,
-                vo,
                 project,
             )
         finally:
@@ -155,9 +154,8 @@ class Dispatcher(base.BaseDispatcher):
                 )
 
             LOG.info(
-                "Image '%s' associated with VO '%s', project '%s'",
+                "Image '%s' associated with project '%s'",
                 image.identifier,
-                vo,
                 project,
             )
 

--- a/atrope/image_list/harbor.py
+++ b/atrope/image_list/harbor.py
@@ -35,7 +35,7 @@ class HarborImageListSource(source.BaseImageListSource):
         tag_pattern=None,
         auth_user=None,
         auth_password=None,
-        verify_ssl=False,
+        verify_ssl=True,
         page_size=50,
         **kwargs,
     ):

--- a/atrope/image_list/harbor.py
+++ b/atrope/image_list/harbor.py
@@ -96,12 +96,12 @@ class HarborImageListSource(source.BaseImageListSource):
         if self._oras_registry is None:
             try:
                 self._oras_registry = oras.provider.Registry(
-                    self.registry_host,
-                    auth_backend="basic",
-                    tls_verify=self.verify_ssl
+                    self.registry_host, auth_backend="basic", tls_verify=self.verify_ssl
                 )
                 self._oras_registry.login(
-                    username=self.auth_user, password=self.auth_password, tls_verify=self.verify_ssl
+                    username=self.auth_user,
+                    password=self.auth_password,
+                    tls_verify=self.verify_ssl,
                 )
             except FileNotFoundError:
                 raise exception.AtropeException(

--- a/atrope/image_list/harbor.py
+++ b/atrope/image_list/harbor.py
@@ -35,7 +35,7 @@ class HarborImageListSource(source.BaseImageListSource):
         tag_pattern=None,
         auth_user=None,
         auth_password=None,
-        verify_ssl=True,
+        verify_ssl=False,
         page_size=50,
         **kwargs,
     ):
@@ -98,9 +98,10 @@ class HarborImageListSource(source.BaseImageListSource):
                 self._oras_registry = oras.provider.Registry(
                     self.registry_host,
                     auth_backend="basic",
+                    tls_verify=self.verify_ssl
                 )
                 self._oras_registry.login(
-                    username=self.auth_user, password=self.auth_password
+                    username=self.auth_user, password=self.auth_password, tls_verify=self.verify_ssl
                 )
             except FileNotFoundError:
                 raise exception.AtropeException(

--- a/atrope/image_list/manager.py
+++ b/atrope/image_list/manager.py
@@ -131,6 +131,8 @@ class YamlImageListManager(BaseImageListManager):
                 file=CONF.sources.image_sources, errno=e.errno
             )
 
+        harbor_base_config = image_lists.pop("harbor", {})
+
         for name, list_meta in image_lists.items():
             source_type = list_meta.pop("type", "hepix").lower()
             if source_type == "hepix":
@@ -148,22 +150,26 @@ class YamlImageListManager(BaseImageListManager):
                 self.lists[name] = lst
             elif source_type == "harbor":
                 try:
+
+                    harbor_config = harbor_base_config.copy()
+                    harbor_config.update(list_meta)
+
                     lst = atrope.image_list.harbor.HarborImageListSource(
                         name=name,
-                        api_url=list_meta.pop("api_url", ""),
-                        project=list_meta.pop("project", ""),
-                        vos=list_meta.pop("vos", []),
-                        registry_host=list_meta.pop("registry_host", ""),
-                        enabled=list_meta.pop("enabled", True),
-                        subscribed_images=list_meta.pop("subscribed_images", []),
-                        prefix=list_meta.pop("prefix", ""),
-                        tag_pattern=list_meta.pop("tag_pattern", None),
-                        auth_user=list_meta.pop("auth_user", None),
-                        auth_password=list_meta.pop("auth_password", None),
-                        auth_token=list_meta.pop("auth_token", None),
-                        verify_ssl=list_meta.pop("verify_ssl", True),
-                        page_size=list_meta.pop("page_size", 50),
-                        **list_meta,
+                        api_url=harbor_config.pop("api_url", ""),
+                        project=harbor_config.pop("project", ""),
+                        vos=harbor_config.pop("vos", []),
+                        registry_host=harbor_config.pop("registry_host", ""),
+                        enabled=harbor_config.pop("enabled", True),
+                        subscribed_images=harbor_config.pop("subscribed_images", []),
+                        prefix=harbor_config.pop("prefix", ""),
+                        tag_pattern=harbor_config.pop("tag_pattern", None),
+                        auth_user=harbor_config.pop("auth_user", None),
+                        auth_password=harbor_config.pop("auth_password", None),
+                        auth_token=harbor_config.pop("auth_token", None),
+                        verify_ssl=harbor_config.pop("verify_ssl", True),
+                        page_size=harbor_config.pop("page_size", 50),
+                        **harbor_config,
                     )
                     self.add_image_list_source(lst)
                     LOG.debug(f"Loaded Harbor source: {name}")

--- a/etc/atrope.conf.sample
+++ b/etc/atrope.conf.sample
@@ -283,6 +283,8 @@
 # User's password (string value)
 #password = <None>
 
+# Image sharing model (string value)
+# sharing_model = community  # or 'shared' for current behaviour
 
 [sources]
 

--- a/etc/sources.yaml.sample
+++ b/etc/sources.yaml.sample
@@ -18,19 +18,25 @@ vo.fedcloud.egi.eu:
     prefix: "FEDCLOUD "
     project: bb02bda767b4490a82b2f62f9347a0f5
 
+# Global Harbor configuration
 harbor:
-    enabled: true
-    type: harbor
     api_url: "http://harbor.adress/api/v2.0"
-    project: "myproject"
     registry_host: "harbor.adress"
-    auth_user: "user"
+    prefix: "HARBOR "
+    verify_ssl: true
+    page_size: 30
+
+# Harbor project configuration
+harbor_project:
+    type: "harbor"
+    enabled: true
+    project: "myproject"
+    auth_user: "user"             
     auth_password: "password"
     images: []
-    prefix: "HARBOR "
-    verify_ssl: false
-    page_size: 30
-    endorser:
+    subscribed_images: []
+    vos:
+        - "vo_name"
 
 foo:
     enabled: false


### PR DESCRIPTION
Several improvements introduced to Atrope:

**Modularized Harbor configuration**
- The Harbor source configuration is now modular, allowing for a global configuration that can be inherited and overridden by individual projects. The verify_ssl attribute is now correctly used when creating the oras Registry.
    
    
**Enhanced Image Sharing**:
- Images that fail to be deleted are now made private and deactivated as a fallback.

- A new community visibility sharing model has been added for making images public.

- Stale Glance memberships are now automatically cleaned up during image sharing.

- Glance Client Caching: A caching mechanism for the Glance client has been implemented to improve performance by reusing client instances and avoiding redundant API calls.


**Related issue :**
Issue #7 