### PR TITLE
Refactor image visibility

### DIFF
--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -159,6 +159,8 @@ class Dispatcher(base.BaseDispatcher):
         LOG.info("Glance dispatching '%s'", image.identifier)
 
         vos = kwargs.pop("vos")
+        if vos:
+            sharing_model = "shared"
 
         # TODO(aloga): missing hypervisor type, need list spec first
         metadata = {

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -17,7 +17,7 @@ import json
 import yaml
 from keystoneauth1 import loading
 from openstack import connection
-from openstack.exceptions import ConflictException, HttpException, ForbiddenException
+from openstack.exceptions import ConflictException, ForbiddenException, HttpException
 from oslo_config import cfg
 from oslo_log import log
 

--- a/atrope/dispatcher/glance.py
+++ b/atrope/dispatcher/glance.py
@@ -17,7 +17,7 @@ import json
 import yaml
 from keystoneauth1 import loading
 from openstack import connection
-from openstack.exceptions import ConflictException, HttpException
+from openstack.exceptions import ConflictException, HttpException, ForbiddenException
 from oslo_config import cfg
 from oslo_log import log
 
@@ -42,15 +42,6 @@ opts = [
         "tag",
         default="atrope",
         help="Tag set on images managed by atrope.",
-    ),
-    cfg.StrOpt(
-        "sharing_model",
-        default="shared",
-        choices=["shared", "community"],
-        help="The sharing model to use for images. 'shared' will use "
-        "Glance image members to share with specific projects. "
-        "'community' will set the image visibility to community, "
-        "making it available to all projects.",
     ),
 ]
 CONF.register_opts(opts, group=CFG_GROUP)
@@ -159,7 +150,7 @@ class Dispatcher(base.BaseDispatcher):
                 project,
             )
 
-    def dispatch(self, image_name, image, is_public, **kwargs):
+    def dispatch(self, image_name, image, sharing_model, **kwargs):
         """Upload an image to the glance service.
 
         If metadata is provided in the kwargs it will be associated with
@@ -168,13 +159,6 @@ class Dispatcher(base.BaseDispatcher):
         LOG.info("Glance dispatching '%s'", image.identifier)
 
         vos = kwargs.pop("vos")
-
-        if CONF.glance.sharing_model == "community":
-            visibility = "community"
-        elif CONF.glance.sharing_model == "shared" and vos:
-            visibility = "shared"
-        else:
-            visibility = "public" if is_public else "private"
 
         # TODO(aloga): missing hypervisor type, need list spec first
         metadata = {
@@ -185,7 +169,7 @@ class Dispatcher(base.BaseDispatcher):
             "disk_format": None,
             "os_distro": image.osname.lower(),
             "os_version": image.osversion,
-            "visibility": visibility,
+            "visibility": sharing_model,
             # AppDB properties
             "vmcatcher_event_dc_description": getattr(image, "description", ""),
             "vmcatcher_event_ad_mpuri": image.mpuri,
@@ -251,25 +235,35 @@ class Dispatcher(base.BaseDispatcher):
 
         if not glance_image:
             LOG.debug("Creating image '%s'.", image.identifier)
-            glance_image = self.client.image.create_image(
-                **metadata, allow_duplicates=True
-            )
+            try:
+                glance_image = self.client.image.create_image(
+                    **metadata, allow_duplicates=True
+                )
+            except ForbiddenException as e:
+                LOG.error("Insufficient permissions to create Image in Glance")
+                raise exception.GlancePermissionError(action=e)
 
         if glance_image.status == "queued":
             LOG.debug("Uploading image '%s'.", image.identifier)
             glance_image.upload(self.client.image, data=image_fd)
 
         if glance_image.status == "active":
-            if glance_image.visibility != visibility:
-                LOG.info("Set image '%s' as '%s'", image.identifier, visibility)
-                self.client.image.update_image(glance_image.id, visibility=visibility)
+            if glance_image.visibility != sharing_model:
+                LOG.info("Set image '%s' as '%s'", image.identifier, sharing_model)
+                try:
+                    self.client.image.update_image(
+                        glance_image.id, visibility=sharing_model
+                    )
+                except ForbiddenException as e:
+                    LOG.error("Insufficient permissions to update Image in Glance")
+                    raise exception.GlancePermissionError(action=e)
             LOG.info(
                 "Image '%s' stored in glance as '%s'.",
                 image.identifier,
                 glance_image.id,
             )
 
-        if CONF.glance.sharing_model == "shared":
+        if sharing_model == "shared":
             for vo in vos:
                 project = self.vo_map.get(vo, {}).get("project_id", "")
                 if not project:
@@ -286,7 +280,7 @@ class Dispatcher(base.BaseDispatcher):
                 else:
                     if glance_image.visibility != "shared":
                         LOG.debug("Set image '%s' as shared", image.identifier)
-                        visibility = "shared"
+                        sharing_model = "shared"
                         self.client.image.update_image(
                             glance_image.id, visibility="shared"
                         )
@@ -294,7 +288,7 @@ class Dispatcher(base.BaseDispatcher):
                         vo=vo, image=image, glance_image=glance_image, project=project
                     )
 
-            self._clean_stale_memberships(glance_image.id, vos, visibility)
+            self._clean_stale_memberships(glance_image.id, vos, sharing_model)
 
     def sync(self, image_list):
         """Sync image list with dispatched images.

--- a/atrope/dispatcher/manager.py
+++ b/atrope/dispatcher/manager.py
@@ -80,9 +80,7 @@ class DispatcherManager(object):
         kwargs.setdefault("project", image_list.project)
         kwargs.setdefault("vos", image_list.vos)
 
-        # this is not working for non admin users
-        # is_public = False if image_list.token else True
-        is_public = False
+        sharing_model = getattr(image_list, "sharing_model", "private")
 
         try:
             images = image_list.get_valid_subscribed_images()
@@ -100,14 +98,14 @@ class DispatcherManager(object):
                 "image name": image.title,
             }
             LOG.info(image_name)
-            self._dispatch_image(image_name, image, is_public, **kwargs)
+            self._dispatch_image(image_name, image, sharing_model, **kwargs)
 
-    def _dispatch_image(self, image_name, image, is_public, **kwargs):
+    def _dispatch_image(self, image_name, image, sharing_model, **kwargs):
         """Dispatch a single image to each of the dispatchers."""
         LOG.info(f"DISPATCHERS: {self.dispatchers}")
         for dispatcher in self.dispatchers:
             try:
-                dispatcher.dispatch(image_name, image, is_public, **kwargs)
+                dispatcher.dispatch(image_name, image, sharing_model, **kwargs)
             except Exception as e:
                 LOG.exception(
                     "An exception has occured when dispatching "

--- a/atrope/exception.py
+++ b/atrope/exception.py
@@ -127,3 +127,7 @@ class MetadataOverwriteNotSupported(AtropeException):
 
 class GlanceInvalidMappingFIle(GlanceError):
     msg_fmt = "Cannot load %(file)s mapping file: %(reason)s."
+
+
+class GlancePermissionError(GlanceError):
+    msg_fmt = "Not authorized to perform Glance action: %(action)s."

--- a/atrope/image_list/harbor.py
+++ b/atrope/image_list/harbor.py
@@ -37,6 +37,7 @@ class HarborImageListSource(source.BaseImageListSource):
         auth_password=None,
         verify_ssl=True,
         page_size=50,
+        sharing_model="private",
         **kwargs,
     ):
         super().__init__(
@@ -62,6 +63,7 @@ class HarborImageListSource(source.BaseImageListSource):
         self._oras_registry = None
         self.endorser = kwargs.get("endorser", {})
         self.token = kwargs.get("token", "")
+        self.sharing_model = sharing_model
 
         # Harbor images are trusted by default, do not expire and do not need verification
         # We may want to change this by adding some metadata in the harbor project

--- a/atrope/image_list/manager.py
+++ b/atrope/image_list/manager.py
@@ -169,6 +169,7 @@ class YamlImageListManager(BaseImageListManager):
                         auth_token=harbor_config.pop("auth_token", None),
                         verify_ssl=harbor_config.pop("verify_ssl", True),
                         page_size=harbor_config.pop("page_size", 50),
+                        sharing_model=harbor_config.pop("sharing_model", "private"),
                         **harbor_config,
                     )
                     self.add_image_list_source(lst)

--- a/etc/sources.yaml.sample
+++ b/etc/sources.yaml.sample
@@ -35,6 +35,7 @@ harbor_project:
     auth_password: "password"
     images: []
     subscribed_images: []
+    sharing_model: "shared" # possible values: "shared", "community", "private", "public"
     vos:
         - "vo_name"
 


### PR DESCRIPTION
# Summary
Refactor visibility configuration - this pull request changes the way visibility of images is set in Glance. Currently in code variable is_public is always set to False and visibility is set globally in glance configuration. The changes in this PR change this to a list-scoped parameter in atrope configuration -  `sharing_model` with possible values: "shared", "community", "private", "public". The default value is "private".

**Related issue :**
#16