### PR TITLE
fix: include registry host in image ref

### DIFF
--- a/atrope/image.py
+++ b/atrope/image.py
@@ -379,7 +379,9 @@ class HarborImage(BaseImage):
                 auth_backend="basic",
             )
             registry.login(username=self.registry_username, password=self.registry_pwd)
-            registry.pull(target=self.image_ref, outdir=location)
+            registry.pull(
+                target=f"{self.registry_host}/{self.image_ref}", outdir=location
+            )
         except FileNotFoundError:
             raise exception.AtropeException(
                 message="oras command not found. Please ensure oras CLI is installed and in PATH."

--- a/atrope/image_list/harbor.py
+++ b/atrope/image_list/harbor.py
@@ -116,7 +116,7 @@ class HarborImageListSource(source.BaseImageListSource):
     def get_manifest(self, image_ref):
         """Helper specifically for running oras pull command."""
         registry = self._get_oras_registry()
-        return registry.get_manifest(image_ref)
+        return registry.get_manifest(f"{self.registry_host}/{image_ref}")
 
     def _fetch_paginated_data(self, url, params=None):
         """Helper to fetch data from a paginated Harbor API endpoint."""


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->

For project names that look like a host name (i.e. with `.`), oras uses the project name as the host making things fail with a name resolution error:

```
2025-08-14 07:30:27.578 16 INFO atrope.image_list.harbor [-] Found 3 repositories in project 'demo.fedcloud.egi.eu'.
2025-08-14 07:30:27.802 16 INFO oras.logger [-] Retrying in 3 seconds - error: HTTPSConnectionPool(host='demo.fedcloud.egi.eu', port=443): Max retries exceeded with url: /v2/alpine/manifests/3.22.1 (Caused by NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7f21805b65d0>: Failed to resolve 'demo.fedcloud.egi.eu' ([Errno -2] Name or service not known)"))
```

This includes the registry host in the image ref to avoid the issue.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
